### PR TITLE
Add healthcheck

### DIFF
--- a/.github/workflows/owasp.yaml
+++ b/.github/workflows/owasp.yaml
@@ -23,9 +23,6 @@ jobs:
       - name: Start Services with Docker Compose
         run: make PROD=1
 
-      - name: Wait for Services to Start
-        run: sleep 30
-
       - name: Run OWASP ZAP Scan
         uses: zaproxy/action-full-scan@v0.12.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: up
 # start services
 up: crypt/unlocked
-	docker compose up --build -d
+	docker compose up --build -d --wait
 
 .PHONY: down
 # stop services

--- a/backend/src/routes.py
+++ b/backend/src/routes.py
@@ -5,8 +5,6 @@ import src.auth.routes
 import src.posts.post_routes
 import src.dashboard.dashboard_routes
 
-@app.route("/hello")
-def hello_world():
-    res = db.session.execute(text("SELECT 1+1")).one()[0]
-    app.logger.info(f"1+1 = {res}")
-    return "Hi from Flask!"
+@app.route("/healthcheck")
+def healthcheck():
+    return "I'm alive!"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,11 @@ services:
     depends_on:
       - frontend
       - backend
+    healthcheck:
+      test: curl -fk https://local.kabir.dev && curl -fk https://local.kabir.dev/api/healthcheck
+      interval: 30s
+      timeout: 10s
+      retries: 5
 volumes:
   db_data:
   redis_data:


### PR DESCRIPTION
This 1) enables `make up` to wait until the services are fully running before it returns, and 2) periodically polls services for health, such that if they stop responding the service will be marked as "unhealthy" in Docker.

Ideally we'd have individual health checks in frontend and backend, but we'd have to install curl in the containers and I don't feel like doing that rn. nginx already has curl so that's where we shall check the health for now 🙃