### PR TITLE
Always run security scan

### DIFF
--- a/.github/workflows/owasp.yaml
+++ b/.github/workflows/owasp.yaml
@@ -1,9 +1,6 @@
 name: DAST Security Scan
 
-on:
-  pull_request:
-    branches:
-      - main
+on: [push]
 
 jobs:
   dast_scan:


### PR DESCRIPTION
Run this on `push`, not just `pull_request`. Importantly, this makes sure we run the scan on commits after they've been merged into main as well (which may behave differently from PRs due to merge order races.)