### PR TITLE
Explicitly set SHELL to bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ ifeq ($(OS),Windows_NT)
 COMPOSE_SEPARATOR = ;
 else
 COMPOSE_SEPARATOR = :
+SHELL = /bin/bash
 endif
 
 ifneq ($(PROD),)


### PR DESCRIPTION
The live server seems to not like `source` (eg in `make psql`) unless we explicitly ask for bash