### PR TITLE
Fix login redirect elision

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -50,7 +50,7 @@ export default function Page() {
         });
         const finishResponseJson = await finishResponse.json();
         if (finishResponseJson.verified) {
-          router.push("/");
+          router.push("/user/dashboard");
         } else {
           setError(true);
           setLoading(false);


### PR DESCRIPTION
I was sometimes getting stuck on the login page after providing my passkey until I reloaded, because we were rerouting to the `/` page again which could get elided. Explicitly load `/user/dashboard` instead.